### PR TITLE
Pass time.Duration to client init, instead of int

### DIFF
--- a/examples/client.go
+++ b/examples/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/gojektech/heimdall"
 	"github.com/pkg/errors"
@@ -14,7 +15,7 @@ const (
 )
 
 func httpClientUsage() error {
-	timeoutInMillis := 100
+	timeoutInMillis := 100 * time.Millisecond
 	httpClient := heimdall.NewHTTPClient(timeoutInMillis)
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")

--- a/http_client.go
+++ b/http_client.go
@@ -20,11 +20,10 @@ type httpClient struct {
 }
 
 // NewHTTPClient returns a new instance of HTTPClient
-func NewHTTPClient(timeoutInMilliseconds int) Client {
-	httpTimeout := time.Duration(timeoutInMilliseconds) * time.Millisecond
+func NewHTTPClient(timeout time.Duration) Client {
 	return &httpClient{
 		client: &http.Client{
-			Timeout: httpTimeout,
+			Timeout: timeout,
 		},
 
 		retryCount: defaultRetryCount,

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -6,13 +6,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPClientDoSuccess(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -41,7 +42,7 @@ func TestHTTPClientDoSuccess(t *testing.T) {
 }
 
 func TestHTTPClientGetSuccess(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
@@ -67,7 +68,7 @@ func TestHTTPClientGetSuccess(t *testing.T) {
 }
 
 func TestHTTPClientPostSuccess(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	requestBodyString := `{ "name": "heimdall" }`
 
@@ -102,7 +103,7 @@ func TestHTTPClientPostSuccess(t *testing.T) {
 }
 
 func TestHTTPClientDeleteSuccess(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
@@ -128,7 +129,7 @@ func TestHTTPClientDeleteSuccess(t *testing.T) {
 }
 
 func TestHTTPClientPutSuccess(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	requestBodyString := `{ "name": "heimdall" }`
 
@@ -163,7 +164,7 @@ func TestHTTPClientPutSuccess(t *testing.T) {
 }
 
 func TestHTTPClientPatchSuccess(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	requestBodyString := `{ "name": "heimdall" }`
 
@@ -198,7 +199,7 @@ func TestHTTPClientPatchSuccess(t *testing.T) {
 }
 
 func TestHTTPClientGetRetriesOnFailure(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	count := 0
 
@@ -227,7 +228,7 @@ func TestHTTPClientGetRetriesOnFailure(t *testing.T) {
 }
 
 func TestHTTPClientGetReturnsAllErrorsIfRetriesFail(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	count := 0
 
@@ -255,7 +256,7 @@ func TestHTTPClientGetReturnsAllErrorsIfRetriesFail(t *testing.T) {
 }
 
 func TestHTTPClientGetReturnsNoErrorsIfRetrySucceeds(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	count := 0
 	countWhenCallSucceeds := 2
@@ -285,7 +286,7 @@ func TestHTTPClientGetReturnsNoErrorsIfRetrySucceeds(t *testing.T) {
 }
 
 func TestHTTPClientGetReturnsErrorOnClientCallFailure(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -304,7 +305,7 @@ func TestHTTPClientGetReturnsErrorOnClientCallFailure(t *testing.T) {
 }
 
 func TestHTTPClientGetReturnsErrorOn5xxFailure(t *testing.T) {
-	client := NewHTTPClient(10)
+	client := NewHTTPClient(10 * time.Millisecond)
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
This avoids the confusion of having both `int` and `time.Duration` as
possible arguments, and the complication of adding a config object if we
were to do that.

Related to #6 