### PR TITLE
Add context support to HTTP client 

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,25 @@ client.SetRetryCount(4)
 // The rest is the same as the first example
 ```
 
+### Support for golang context
+
+To make use of golang context, you can use the `NewHTTPClientWithContext` method. example:
+```go
+client := heimdall.NewHTTPClientWithContext(10 * time.Second)
+
+ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+defer cancel()
+
+req, _ := http.NewRequest(http.MethodGet, "http://google.com", nil)
+
+response, err := client.Get(ctx, req)
+
+//use the response.
+
+```
+
+* The client returned by `NewHTTPClientWithContext` supports all methods supported by hystrix or the HTTP client.
+
 ## Documentation
 
 Further documentation can be found on [godoc.org](https://www.godoc.org/github.com/gojektech/heimdall)

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package heimdall
 
 import (
+	"context"
 	"io"
 	"net/http"
 )
@@ -13,6 +14,19 @@ type Client interface {
 	Patch(url string, body io.Reader, headers http.Header) (*http.Response, error)
 	Delete(url string, headers http.Header) (*http.Response, error)
 	Do(req *http.Request) (*http.Response, error)
+
+	SetRetryCount(count int)
+	SetRetrier(retrier Retriable)
+}
+
+// ClientWithContext is a generic HTTP client interface which supports golang context
+type ClientWithContext interface {
+	Get(ctx context.Context, url string, headers http.Header) (*http.Response, error)
+	Post(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error)
+	Put(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error)
+	Patch(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error)
+	Delete(ctx context.Context, url string, headers http.Header) (*http.Response, error)
+	Do(ctx context.Context, req *http.Request) (*http.Response, error)
 
 	SetRetryCount(count int)
 	SetRetrier(retrier Retriable)

--- a/context_client.go
+++ b/context_client.go
@@ -3,6 +3,7 @@ package heimdall
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -15,6 +16,18 @@ type httpClientWithContext struct {
 
 	retryCount int
 	retrier    Retriable
+}
+
+func (c *httpClientWithContext) Patch(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error) {
+	var response *http.Response
+	request, err := http.NewRequest(http.MethodPatch, url, body)
+	if err != nil {
+		return response, errors.Wrap(err, "PATCH - request creation failed")
+	}
+
+	request.Header = headers
+
+	return c.Do(ctx, request)
 }
 
 func (c *httpClientWithContext) Delete(ctx context.Context, url string, headers http.Header) (*http.Response, error) {

--- a/context_client.go
+++ b/context_client.go
@@ -18,6 +18,18 @@ type httpClientWithContext struct {
 	retrier    Retriable
 }
 
+func (c *httpClientWithContext) Post(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error) {
+	var response *http.Response
+	request, err := http.NewRequest(http.MethodPost, url, body)
+	if err != nil {
+		return response, errors.Wrap(err, "POST - request creation failed")
+	}
+
+	request.Header = headers
+
+	return c.Do(ctx, request)
+}
+
 func (c *httpClientWithContext) Put(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error) {
 	var response *http.Response
 	request, err := http.NewRequest(http.MethodPut, url, body)

--- a/context_client.go
+++ b/context_client.go
@@ -1,0 +1,58 @@
+package heimdall
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gojektech/valkyrie"
+)
+
+type httpClientWithContext struct {
+	client *http.Client
+
+	retryCount int
+	retrier    Retriable
+}
+
+func (c *httpClientWithContext) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
+	var response *http.Response
+	var contextCancelled bool = false
+
+	multiErr := &valkyrie.MultiError{}
+
+	for i := 0; i <= c.retryCount; i++ {
+		var err error
+		response, err = c.client.Do(req.WithContext(ctx))
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				err = ctx.Err()
+				contextCancelled = true
+			}
+
+			multiErr.Push(err.Error())
+			if contextCancelled {
+				break
+			}
+			backoffTime := c.retrier.NextInterval(i)
+			time.Sleep(backoffTime)
+			continue
+		}
+
+		if response.StatusCode >= http.StatusInternalServerError {
+			multiErr.Push(fmt.Sprintf("server error: %d", response.StatusCode))
+
+			backoffTime := c.retrier.NextInterval(i)
+			time.Sleep(backoffTime)
+			fmt.Println("R: ", response.StatusCode)
+			continue
+		}
+
+		multiErr = &valkyrie.MultiError{} // Clear errors if any iteration succeeds
+		break
+	}
+
+	return response, multiErr.HasError()
+}

--- a/context_client.go
+++ b/context_client.go
@@ -18,6 +18,18 @@ type httpClientWithContext struct {
 	retrier    Retriable
 }
 
+func (c *httpClientWithContext) Get(ctx context.Context, url string, headers http.Header) (*http.Response, error) {
+	var response *http.Response
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return response, errors.Wrap(err, "GET - request creation failed")
+	}
+
+	request.Header = headers
+
+	return c.Do(ctx, request)
+}
+
 func (c *httpClientWithContext) Post(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error) {
 	var response *http.Response
 	request, err := http.NewRequest(http.MethodPost, url, body)

--- a/context_client.go
+++ b/context_client.go
@@ -18,14 +18,17 @@ type httpClientWithContext struct {
 	retrier    Retriable
 }
 
+// SetRetryCount sets the retry count for the httpClient
 func (c *httpClientWithContext) SetRetryCount(count int) {
 	c.retryCount = count
 }
 
+// SetRetryCount sets the retry count for the httpClient
 func (c *httpClientWithContext) SetRetrier(retrier Retriable) {
 	c.retrier = retrier
 }
 
+// Get makes a HTTP GET request to provided URL with context passed in
 func (c *httpClientWithContext) Get(ctx context.Context, url string, headers http.Header) (*http.Response, error) {
 	var response *http.Response
 	request, err := http.NewRequest(http.MethodGet, url, nil)
@@ -38,6 +41,7 @@ func (c *httpClientWithContext) Get(ctx context.Context, url string, headers htt
 	return c.Do(ctx, request)
 }
 
+// Post makes a HTTP POST request to provided URL with context passed in
 func (c *httpClientWithContext) Post(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error) {
 	var response *http.Response
 	request, err := http.NewRequest(http.MethodPost, url, body)
@@ -50,6 +54,7 @@ func (c *httpClientWithContext) Post(ctx context.Context, url string, body io.Re
 	return c.Do(ctx, request)
 }
 
+// Put makes a HTTP PUT request to provided URL with context passed in
 func (c *httpClientWithContext) Put(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error) {
 	var response *http.Response
 	request, err := http.NewRequest(http.MethodPut, url, body)
@@ -62,6 +67,7 @@ func (c *httpClientWithContext) Put(ctx context.Context, url string, body io.Rea
 	return c.Do(ctx, request)
 }
 
+// Patch makes a HTTP PATCH request to provided URL with context passed in
 func (c *httpClientWithContext) Patch(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error) {
 	var response *http.Response
 	request, err := http.NewRequest(http.MethodPatch, url, body)
@@ -74,6 +80,7 @@ func (c *httpClientWithContext) Patch(ctx context.Context, url string, body io.R
 	return c.Do(ctx, request)
 }
 
+// Delete makes a HTTP DELETE request to provided URL with context passed in
 func (c *httpClientWithContext) Delete(ctx context.Context, url string, headers http.Header) (*http.Response, error) {
 	var response *http.Response
 	request, err := http.NewRequest(http.MethodDelete, url, nil)
@@ -86,6 +93,7 @@ func (c *httpClientWithContext) Delete(ctx context.Context, url string, headers 
 	return c.Do(ctx, request)
 }
 
+// Do makes an HTTP request with the native `http.Do` interface and context passed in
 func (c *httpClientWithContext) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	var response *http.Response
 	var contextCancelled bool = false

--- a/context_client.go
+++ b/context_client.go
@@ -18,6 +18,18 @@ type httpClientWithContext struct {
 	retrier    Retriable
 }
 
+func (c *httpClientWithContext) Put(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error) {
+	var response *http.Response
+	request, err := http.NewRequest(http.MethodPut, url, body)
+	if err != nil {
+		return response, errors.Wrap(err, "PUT - request creation failed")
+	}
+
+	request.Header = headers
+
+	return c.Do(ctx, request)
+}
+
 func (c *httpClientWithContext) Patch(ctx context.Context, url string, body io.Reader, headers http.Header) (*http.Response, error) {
 	var response *http.Response
 	request, err := http.NewRequest(http.MethodPatch, url, body)

--- a/context_client.go
+++ b/context_client.go
@@ -18,6 +18,14 @@ type httpClientWithContext struct {
 	retrier    Retriable
 }
 
+func (c *httpClientWithContext) SetRetryCount(count int) {
+	c.retryCount = count
+}
+
+func (c *httpClientWithContext) SetRetrier(retrier Retriable) {
+	c.retrier = retrier
+}
+
 func (c *httpClientWithContext) Get(ctx context.Context, url string, headers http.Header) (*http.Response, error) {
 	var response *http.Response
 	request, err := http.NewRequest(http.MethodGet, url, nil)

--- a/context_client.go
+++ b/context_client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gojektech/valkyrie"
+	"github.com/pkg/errors"
 )
 
 type httpClientWithContext struct {
@@ -14,6 +15,18 @@ type httpClientWithContext struct {
 
 	retryCount int
 	retrier    Retriable
+}
+
+func (c *httpClientWithContext) Delete(ctx context.Context, url string, headers http.Header) (*http.Response, error) {
+	var response *http.Response
+	request, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return response, errors.Wrap(err, "DELETE - request creation failed")
+	}
+
+	request.Header = headers
+
+	return c.Do(ctx, request)
 }
 
 func (c *httpClientWithContext) Do(ctx context.Context, req *http.Request) (*http.Response, error) {

--- a/context_client_test.go
+++ b/context_client_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHTTPClientWithContextSuccessWithTODOContext(t *testing.T) {
+func TestHTTPClientWithContextSuccess(t *testing.T) {
 	client := NewHTTPClientWithContext(10 * time.Millisecond)
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +42,7 @@ func TestHTTPClientWithContextSuccessWithTODOContext(t *testing.T) {
 	assert.Equal(t, "{ \"response\": \"ok\" }", string(body))
 }
 
-func TestHTTPClientWithContextGetSuccessWithTODOContext(t *testing.T) {
+func TestHTTPClientWithContextGetSuccess(t *testing.T) {
 	client := NewHTTPClientWithContext(10 * time.Millisecond)
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
@@ -68,7 +68,7 @@ func TestHTTPClientWithContextGetSuccessWithTODOContext(t *testing.T) {
 	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
 }
 
-func TestHTTPClientWithContextPostSuccessWithTODOContext(t *testing.T) {
+func TestHTTPClientWithContextPostSuccess(t *testing.T) {
 	client := NewHTTPClientWithContext(10 * time.Millisecond)
 
 	requestBodyString := `{ "name": "heimdall" }`
@@ -103,7 +103,7 @@ func TestHTTPClientWithContextPostSuccessWithTODOContext(t *testing.T) {
 	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
 }
 
-func TestHTTPClientWithContextDeleteSuccessWithTODOContext(t *testing.T) {
+func TestHTTPClientWithContextDeleteSuccess(t *testing.T) {
 	client := NewHTTPClientWithContext(10 * time.Millisecond)
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
@@ -129,7 +129,7 @@ func TestHTTPClientWithContextDeleteSuccessWithTODOContext(t *testing.T) {
 	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
 }
 
-func TestHTTPClientWithContextPutSuccessWithTODOContext(t *testing.T) {
+func TestHTTPClientWithContextPutSuccess(t *testing.T) {
 	client := NewHTTPClientWithContext(10 * time.Millisecond)
 
 	requestBodyString := `{ "name": "heimdall" }`
@@ -164,7 +164,7 @@ func TestHTTPClientWithContextPutSuccessWithTODOContext(t *testing.T) {
 	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
 }
 
-func TestHTTPClientWithContextPatchSuccessWithTODOContext(t *testing.T) {
+func TestHTTPClientWithContextPatchSuccess(t *testing.T) {
 	client := NewHTTPClientWithContext(10 * time.Millisecond)
 
 	requestBodyString := `{ "name": "heimdall" }`

--- a/context_client_test.go
+++ b/context_client_test.go
@@ -40,3 +40,29 @@ func TestHTTPClientWithContextSuccessWithTODOContext(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "{ \"response\": \"ok\" }", string(body))
 }
+
+func TestHTTPClientWithContextGetSuccessWithTODOContext(t *testing.T) {
+	client := NewHTTPClientWithContext(10 * time.Millisecond)
+
+	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
+		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{ "response": "ok" }`))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(dummyHandler))
+	defer server.Close()
+
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Accept-Language", "en")
+
+	response, err := client.Get(context.TODO(), server.URL, headers)
+	require.NoError(t, err, "should not have failed to make a GET request")
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
+}

--- a/context_client_test.go
+++ b/context_client_test.go
@@ -102,3 +102,29 @@ func TestHTTPClientWithContextPostSuccessWithTODOContext(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
 }
+
+func TestHTTPClientWithContextDeleteSuccessWithTODOContext(t *testing.T) {
+	client := NewHTTPClientWithContext(10 * time.Millisecond)
+
+	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
+		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{ "response": "ok" }`))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(dummyHandler))
+	defer server.Close()
+
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Accept-Language", "en")
+
+	response, err := client.Delete(context.TODO(), server.URL, headers)
+	require.NoError(t, err, "should not have failed to make a DELETE request")
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
+}

--- a/context_client_test.go
+++ b/context_client_test.go
@@ -163,3 +163,38 @@ func TestHTTPClientWithContextPutSuccessWithTODOContext(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
 }
+
+func TestHTTPClientWithContextPatchSuccessWithTODOContext(t *testing.T) {
+	client := NewHTTPClientWithContext(10 * time.Millisecond)
+
+	requestBodyString := `{ "name": "heimdall" }`
+
+	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
+		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+
+		rBody, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err, "should not have failed to extract request body")
+
+		assert.Equal(t, requestBodyString, string(rBody))
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{ "response": "ok" }`))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(dummyHandler))
+	defer server.Close()
+
+	requestBody := bytes.NewReader([]byte(requestBodyString))
+
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Accept-Language", "en")
+
+	response, err := client.Patch(context.TODO(), server.URL, requestBody, headers)
+	require.NoError(t, err, "should not have failed to make a PATCH request")
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
+}

--- a/context_client_test.go
+++ b/context_client_test.go
@@ -128,3 +128,38 @@ func TestHTTPClientWithContextDeleteSuccessWithTODOContext(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
 }
+
+func TestHTTPClientWithContextPutSuccessWithTODOContext(t *testing.T) {
+	client := NewHTTPClientWithContext(10 * time.Millisecond)
+
+	requestBodyString := `{ "name": "heimdall" }`
+
+	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
+		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+
+		rBody, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err, "should not have failed to extract request body")
+
+		assert.Equal(t, requestBodyString, string(rBody))
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{ "response": "ok" }`))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(dummyHandler))
+	defer server.Close()
+
+	requestBody := bytes.NewReader([]byte(requestBodyString))
+
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Accept-Language", "en")
+
+	response, err := client.Put(context.TODO(), server.URL, requestBody, headers)
+	require.NoError(t, err, "should not have failed to make a PUT request")
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "{ \"response\": \"ok\" }", respBody(t, response))
+}

--- a/context_client_test.go
+++ b/context_client_test.go
@@ -227,3 +227,35 @@ func TestHTTPClientWithContextFailure(t *testing.T) {
 
 	assert.Nil(t, response)
 }
+
+func TestHTTPClientWithContextFailureWhenContextTimesOut(t *testing.T) {
+	client := NewHTTPClientWithContext(10 * time.Millisecond)
+
+	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
+		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{ "response": "ok" }`))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(dummyHandler))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Language", "en")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	time.Sleep(2 * time.Second)
+
+	response, err := client.Do(ctx, req)
+
+	require.Error(t, err, "context deadline exceeded")
+
+	assert.Nil(t, response)
+}


### PR DESCRIPTION
* introduced a new interface `ClientWithContext` 
* currently implemented by HTTP client and not for hystrix client. PR would have been too large.