### PR TITLE
Storing request buffer to create new reader on each request

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -118,19 +118,24 @@ func (c *httpClient) Delete(url string, headers http.Header) (*http.Response, er
 func (c *httpClient) Do(request *http.Request) (*http.Response, error) {
 	request.Close = true
 
-	// Storing request buffer to create new reader on each request
-	buf, err := ioutil.ReadAll(request.Body)
+	var reqBuffer []byte
 
-	if err != nil {
-		return nil, err
+	if request != nil && request.Body != nil {
+		var err error
+
+		// Storing request buffer to create new reader on each request
+		reqBuffer, err = ioutil.ReadAll(request.Body)
+
+		if err != nil {
+			return nil, err
+		}
 	}
-
 	multiErr := &valkyrie.MultiError{}
 	var response *http.Response
 
 	for i := 0; i <= c.retryCount; i++ {
 		var err error
-		request.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+		request.Body = ioutil.NopCloser(bytes.NewBuffer(reqBuffer))
 		response, err = c.client.Do(request)
 		if err != nil {
 			multiErr.Push(err.Error())


### PR DESCRIPTION
This PR resolves the issue with drained request payload buffer after the first request.
When you repeat the request with the same buffer, you should fill or seek to the beginning before next usage. 