### PR TITLE
Remove Println on 5xx errors in Do method

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -150,7 +150,6 @@ func (c *httpClient) Do(request *http.Request) (*http.Response, error) {
 
 			backoffTime := c.retrier.NextInterval(i)
 			time.Sleep(backoffTime)
-			fmt.Println("R: ", response.StatusCode)
 			continue
 		}
 


### PR DESCRIPTION
Hello! 

The call to `fmt.Println` on 5xx statuses in the `Do` method does not contain more information than the error pushed in `multiErr` but does pollute the standard output.
What do you think?