### PR TITLE
Fix the ordering of expected and actual in some assert.Equal calls

### DIFF
--- a/http_client_test.go
+++ b/http_client_test.go
@@ -17,8 +17,8 @@ func TestHTTPClientDoSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{ "response": "ok" }`))
@@ -46,8 +46,8 @@ func TestHTTPClientGetSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{ "response": "ok" }`))
@@ -74,8 +74,8 @@ func TestHTTPClientPostSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		rBody, err := ioutil.ReadAll(r.Body)
 		require.NoError(t, err, "should not have failed to extract request body")
@@ -107,8 +107,8 @@ func TestHTTPClientDeleteSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{ "response": "ok" }`))
@@ -135,8 +135,8 @@ func TestHTTPClientPutSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		rBody, err := ioutil.ReadAll(r.Body)
 		require.NoError(t, err, "should not have failed to extract request body")
@@ -170,8 +170,8 @@ func TestHTTPClientPatchSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		rBody, err := ioutil.ReadAll(r.Body)
 		require.NoError(t, err, "should not have failed to extract request body")
@@ -348,8 +348,8 @@ func TestCustomHTTPClientHeaderSuccess(t *testing.T) {
 		client: http.Client{Timeout: 25 * time.Millisecond}})
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Header.Get("foo"), "bar")
-		assert.NotEqual(t, r.Header.Get("foo"), "baz")
+		assert.Equal(t, "bar", r.Header.Get("foo"))
+		assert.NotEqual(t, "baz", r.Header.Get("foo"))
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{ "response": "ok" }`))
 	}

--- a/hystrix_client_test.go
+++ b/hystrix_client_test.go
@@ -34,8 +34,8 @@ func TestHystrixHTTPClientDoSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{ "response": "ok" }`))
@@ -75,8 +75,8 @@ func TestHystrixHTTPClientGetSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{ "response": "ok" }`))
@@ -115,8 +115,8 @@ func TestHystrixHTTPClientPostSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		rBody, err := ioutil.ReadAll(r.Body)
 		require.NoError(t, err, "should not have failed to extract request body")
@@ -160,8 +160,8 @@ func TestHystrixHTTPClientDeleteSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{ "response": "ok" }`))
@@ -200,8 +200,8 @@ func TestHystrixHTTPClientPutSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		rBody, err := ioutil.ReadAll(r.Body)
 		require.NoError(t, err, "should not have failed to extract request body")
@@ -247,8 +247,8 @@ func TestHystrixHTTPClientPatchSuccess(t *testing.T) {
 
 	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
-		assert.Equal(t, r.Header.Get("Content-Type"), "application/json")
-		assert.Equal(t, r.Header.Get("Accept-Language"), "en")
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "en", r.Header.Get("Accept-Language"))
 
 		rBody, err := ioutil.ReadAll(r.Body)
 		require.NoError(t, err, "should not have failed to extract request body")


### PR DESCRIPTION
Some calls to `assert.Equal` were inverting the order of the expected and actual values, rendering the  output of failed tests in the wrong way