### PR TITLE
Fix jitter interval in example and update doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ In the above example, the `fallbackFunc` is a function which posts to channel tw
 ```go
 // First set a backoff mechanism. Constant backoff increases the backoff at a constant rate
 backoffInterval := 2 * time.Millisecond
+// Define a maximum jitter interval. It must be more than 1*time.Millisecond
 maximumJitterInterval := 5 * time.Millisecond
 
 backoff := heimdall.NewConstantBackoff(backoffInterval, maximumJitterInterval)
@@ -166,7 +167,7 @@ Or create client with exponential backoff
 initalTimeout := 2*time.Millisecond            // Inital timeout
 maxTimeout := 9*time.Millisecond               // Max time out
 exponentFactor := 2                            // Multiplier
-maximumJitterInterval := 2*time.Millisecond    // Max jitter interval
+maximumJitterInterval := 2*time.Millisecond    // Max jitter interval. It must be more than 1*time.Millisecond
 
 backoff := heimdall.NewExponentialBackoff(initalTimeout, maxTimeout, exponentFactor, maximumJitterInterval)
 

--- a/backoff.go
+++ b/backoff.go
@@ -21,6 +21,7 @@ func init() {
 }
 
 // NewConstantBackoff returns an instance of ConstantBackoff
+// The maximum jitter interval must be more than 1*time.Millisecond
 func NewConstantBackoff(backoffInterval, maximumJitterInterval time.Duration) Backoff {
 	return &constantBackoff{
 		backoffInterval:       int64(backoffInterval / time.Millisecond),
@@ -33,7 +34,6 @@ func (cb *constantBackoff) Next(retry int) time.Duration {
 	if retry <= 0 {
 		return 0 * time.Millisecond
 	}
-
 	return (time.Duration(cb.backoffInterval) * time.Millisecond) + (time.Duration(rand.Int63n(cb.maximumJitterInterval)) * time.Millisecond)
 }
 
@@ -45,6 +45,7 @@ type exponentialBackoff struct {
 }
 
 // NewExponentialBackoff returns an instance of ExponentialBackoff
+// The maximum jitter interval must be more than 1*time.Millisecond
 func NewExponentialBackoff(initialTimeout, maxTimeout time.Duration, exponentFactor float64, maximumJitterInterval time.Duration) Backoff {
 	return &exponentialBackoff{
 		exponentFactor:        exponentFactor,
@@ -59,6 +60,5 @@ func (eb *exponentialBackoff) Next(retry int) time.Duration {
 	if retry <= 0 {
 		return 0 * time.Millisecond
 	}
-
 	return time.Duration(math.Min(eb.initialTimeout+math.Pow(eb.exponentFactor, float64(retry)), eb.maxTimeout)+float64(rand.Int63n(eb.maximumJitterInterval))) * time.Millisecond
 }

--- a/examples/client.go
+++ b/examples/client.go
@@ -22,7 +22,7 @@ func httpClientUsage() error {
 	httpClient := httpclient.NewClient(
 		httpclient.WithHTTPTimeout(timeout),
 		httpclient.WithRetryCount(2),
-		httpclient.WithRetrier(heimdall.NewRetrier(heimdall.NewConstantBackoff(10, 5))),
+		httpclient.WithRetrier(heimdall.NewRetrier(heimdall.NewConstantBackoff(10, 50*time.Millisecond))),
 	)
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
@@ -88,7 +88,7 @@ func customHTTPClientUsage() error {
 			client: http.Client{Timeout: 25 * time.Millisecond},
 		}),
 		httpclient.WithRetryCount(2),
-		httpclient.WithRetrier(heimdall.NewRetrier(heimdall.NewConstantBackoff(10, 5))),
+		httpclient.WithRetrier(heimdall.NewRetrier(heimdall.NewConstantBackoff(10, 50*time.Millisecond))),
 	)
 
 	headers := http.Header{}

--- a/examples/client.go
+++ b/examples/client.go
@@ -22,7 +22,7 @@ func httpClientUsage() error {
 	httpClient := httpclient.NewClient(
 		httpclient.WithHTTPTimeout(timeout),
 		httpclient.WithRetryCount(2),
-		httpclient.WithRetrier(heimdall.NewRetrier(heimdall.NewConstantBackoff(10, 50*time.Millisecond))),
+		httpclient.WithRetrier(heimdall.NewRetrier(heimdall.NewConstantBackoff(10*time.Millisecond, 50*time.Millisecond))),
 	)
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
@@ -88,7 +88,7 @@ func customHTTPClientUsage() error {
 			client: http.Client{Timeout: 25 * time.Millisecond},
 		}),
 		httpclient.WithRetryCount(2),
-		httpclient.WithRetrier(heimdall.NewRetrier(heimdall.NewConstantBackoff(10, 50*time.Millisecond))),
+		httpclient.WithRetrier(heimdall.NewRetrier(heimdall.NewConstantBackoff(10*time.Millisecond, 50*time.Millisecond))),
 	)
 
 	headers := http.Header{}

--- a/hystrix/hystrix_client_test.go
+++ b/hystrix/hystrix_client_test.go
@@ -28,7 +28,7 @@ func TestHystrixHTTPClientDoSuccess(t *testing.T) {
 	client := NewClient(
 		WithHTTPTimeout(50*time.Millisecond),
 		WithCommandName("some_command_name"),
-		WithHystrixTimeout(10),
+		WithHystrixTimeout(10*time.Millisecond),
 		WithMaxConcurrentRequests(100),
 		WithErrorPercentThreshold(10),
 		WithSleepWindow(100),
@@ -352,7 +352,7 @@ func TestHystrixHTTPClientRetriesPostOnFailure(t *testing.T) {
 	client := NewClient(
 		WithHTTPTimeout(50*time.Millisecond),
 		WithCommandName("some_command_name"),
-		WithHystrixTimeout(10),
+		WithHystrixTimeout(10*time.Millisecond),
 		WithMaxConcurrentRequests(100),
 		WithErrorPercentThreshold(10),
 		WithSleepWindow(100),


### PR DESCRIPTION
The maximum jitter interval was set to `5` in the examples, leading to a 0 input to `rand.Int63n`, which leads to a panic.

I also update the README and the doc of `NewConstantBackoff` and `NewExponentialBackoff`